### PR TITLE
`mkNonEmptyTextWithTruncate`: truncate after char stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.0.2] - 2022-10-18
+
+- Fix `mkNonEmptyTextWithTruncate` to perform truncation after character stripping.
+
 ## [0.1.0.1] - 2022-09-29
 
 - Fix building on GHC 8.10.7, and add it to CI.

--- a/src/Data/StringVariants/NonEmptyText.hs
+++ b/src/Data/StringVariants/NonEmptyText.hs
@@ -12,6 +12,7 @@ module Data.StringVariants.NonEmptyText
 
     -- * Construction
     mkNonEmptyText,
+    mkNonEmptyTextWithTruncate,
     unsafeMkNonEmptyText,
     nonEmptyTextToText,
     compileNonEmptyText,

--- a/src/Data/StringVariants/NonEmptyText/Internal.hs
+++ b/src/Data/StringVariants/NonEmptyText/Internal.hs
@@ -81,6 +81,13 @@ mkNonEmptyText t
   where
     stripped = T.filter (/= '\NUL') $ T.strip t
 
+mkNonEmptyTextWithTruncate :: forall n. KnownNat n => Text -> Maybe (NonEmptyText n)
+mkNonEmptyTextWithTruncate t
+  | textIsWhitespace stripped = Nothing
+  | otherwise = Just (NonEmptyText $ T.stripEnd $ T.take (fromIntegral $ natVal (Proxy @n)) stripped)
+  where
+    stripped = T.filter (/= '\NUL') $ T.strip t
+
 -- | Make a NonEmptyText when you can manually verify the length
 unsafeMkNonEmptyText :: forall n. KnownNat n => Text -> NonEmptyText n
 unsafeMkNonEmptyText = NonEmptyText

--- a/src/Data/StringVariants/NullableNonEmptyText.hs
+++ b/src/Data/StringVariants/NullableNonEmptyText.hs
@@ -63,9 +63,6 @@ mkNullableNonEmptyText t
   | textIsTooLong t (fromIntegral $ natVal (Proxy @n)) = Nothing -- we can't store text that is too long
   | otherwise = Just $ NullableNonEmptyText $ mkNonEmptyText t
 
-mkNonEmptyTextWithTruncate :: forall n. KnownNat n => Text -> Maybe (NonEmptyText n)
-mkNonEmptyTextWithTruncate = mkNonEmptyText . T.take (fromInteger (natVal (Proxy @n)))
-
 nullNonEmptyText :: NullableNonEmptyText n
 nullNonEmptyText = NullableNonEmptyText Nothing
 

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           string-variants
-version:        0.1.0.1
+version:        0.1.0.2
 synopsis:       Constrained text newtypes
 description:    See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category:       Data


### PR DESCRIPTION
For sake of example, lets construct a `NonEmptyText 7`.

Construction via `mkNonEmptyText` will strip whitespace and NUL characters before checking to see if it fits within 7 characters.

On the contrary, construction via `mkNonEmptyTextWithTruncate` will call `mkNonEmptyText` with the first 7 characters, which are then stripped. This means the resulting `NonEmptyText 7` could actually contain a text that is smaller than expected.
I believe this behavior is counter-intuitive and incorrect.

#### Example
```hs
>mkNonEmptyText @7 "  example  "
Just (NonEmptyText "example")

>mkNonEmptyText @9 "  example  "
Just (NonEmptyText "example")

-- existing behavior
>mkNonEmptyTextWithTruncate @7 "  example  to-be-truncated...    "
Just (NonEmptyText "examp")

-- new behavior
>mkNonEmptyTextWithTruncate @7 "  example  to-be-truncated...   "
Just (NonEmptyText "example")

>mkNonEmptyTextWithTruncate @9 "  example  to-be-truncated...   "
Just (NonEmptyText "example")
```

#### Notes
* `mkNonEmptyTextWithTruncate` moved from `Data.StringVariants.NullableNonEmptyText` to `Data.StringVariants.NonEmptyText.Internal` due to `NonEmptyText` construction.
  * In any case, it seemed out of place in `Data.StringVariants.NullableNonEmptyText` since it didn't actually create a `NullableNonEmptyText`.
* I left the (re-)export of `mkNonEmptyTextWithTruncate` from `Data.StringVariants.NullableNonEmptyText` to maintain import backwards compatibility but since this library is still new, we could remove it.