### PR TITLE
Fix string manipulation

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220826
+# version: 0.15.20221107
 #
-# REGENDATA ("0.15.20220826",["github","string-variants.cabal"])
+# REGENDATA ("0.15.20221107",["github","string-variants.cabal"])
 #
 name: Haskell-CI
 on:
@@ -181,6 +181,9 @@ jobs:
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
+      - name: tests
+        run: |
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: cabal check
         run: |
           cd ${PKGDIR_string_variants} || false

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -38,11 +38,6 @@ jobs:
             compilerVersion: 9.2.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.7
-            compilerKind: ghc
-            compilerVersion: 8.10.7
-            setup-method: ghcup
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/package.yaml
+++ b/package.yaml
@@ -29,6 +29,25 @@ dependencies:
 library:
   source-dirs: src
 
+# Test suite
+tests:
+  test:
+    main: Main.hs
+    source-dirs:
+      - test
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
+      - -Wno-incomplete-uni-patterns # Failing at runtime just means failing the test, which is ok
+      - -O0
+    dependencies:
+      - HUnit
+      - hspec
+      - hspec-core
+      - hspec-expectations
+      - string-variants
+
 # from https://medium.com/mercury-bank/enable-all-the-warnings-a0517bc081c3
 ghc-options:
   - -Weverything

--- a/package.yaml
+++ b/package.yaml
@@ -1,12 +1,11 @@
 name: string-variants
-version: 0.2.0
+version: 0.2.0.0
 synopsis: Constrained text newtypes
 description: See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category: Data
 github: MercuryTechnologies/string-variants
 
-# FIXME(jadel): find other maintainers also
-maintainer: Jade Lovelace <jadel@mercury.com>
+maintainer: Jade Lovelace <jadel@mercury.com>, Borys Lykakh <borys@fastmail.com>
 extra-source-files:
   - CHANGELOG.md
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: string-variants
-version: 0.1.0.1
+version: 0.1.1
 synopsis: Constrained text newtypes
 description: See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category: Data

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ tested-with: GHC ==9.2.4 || ==9.4.2
 # FIXME(jadel): maybe instances should be in a separate package but whatever
 dependencies:
   - aeson >= 2.0.0.0
-  - base >= 4.9 && <5
+  - base >= 4.16 && <5
   - bytestring
   - mono-traversable
   - QuickCheck

--- a/package.yaml
+++ b/package.yaml
@@ -11,7 +11,7 @@ extra-source-files:
 
 license: MIT
 
-tested-with: GHC ==8.10.7 || ==9.2.4 || ==9.4.2
+tested-with: GHC ==9.2.4 || ==9.4.2
 # FIXME(jadel): maybe instances should be in a separate package but whatever
 dependencies:
   - aeson >= 2.0.0.0

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: string-variants
-version: 0.1.1
+version: 0.2.0
 synopsis: Constrained text newtypes
 description: See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category: Data

--- a/package.yaml
+++ b/package.yaml
@@ -41,10 +41,13 @@ tests:
       - -Wno-incomplete-uni-patterns # Failing at runtime just means failing the test, which is ok
       - -O0
     dependencies:
+      - hedgehog
       - HUnit
       - hspec
       - hspec-core
+      - hspec-discover
       - hspec-expectations
+      - hspec-hedgehog
       - string-variants
 
 # from https://medium.com/mercury-bank/enable-all-the-warnings-a0517bc081c3

--- a/package.yaml
+++ b/package.yaml
@@ -41,14 +41,15 @@ tests:
       - -Wno-incomplete-uni-patterns # Failing at runtime just means failing the test, which is ok
       - -O0
     dependencies:
-      - hedgehog
       - HUnit
+      - hedgehog
       - hspec
       - hspec-core
-      - hspec-discover
-      - hspec-expectations
       - hspec-hedgehog
+      - hspec-expectations
       - string-variants
+    build-tools:
+      - hspec-discover
 
 # from https://medium.com/mercury-bank/enable-all-the-warnings-a0517bc081c3
 ghc-options:

--- a/src/Data/StringVariants.hs
+++ b/src/Data/StringVariants.hs
@@ -51,9 +51,6 @@ module Data.StringVariants
 
     -- ** Information
     isNullNonEmptyText,
-
-    -- * Convenience util if you need a NonEmptyText of a dynamically determined lengths
-    useNat,
   )
 where
 

--- a/src/Data/StringVariants.hs
+++ b/src/Data/StringVariants.hs
@@ -54,7 +54,6 @@ module Data.StringVariants
 
     -- * Convenience util if you need a NonEmptyText of a dynamically determined lengths
     useNat,
-    natOfLength,
   )
 where
 

--- a/src/Data/StringVariants/NonEmptyText.hs
+++ b/src/Data/StringVariants/NonEmptyText.hs
@@ -82,6 +82,8 @@ nonEmptyTextToText (NonEmptyText t) = t
 -- | Identical to the normal text filter function, but maintains the type-level invariant
 -- that the text length is <= n, unlike unwrapping the text, filtering, then
 -- rewrapping the text.
+--
+-- Will return Nothing if the resulting length is zero.
 filterNonEmptyText :: (KnownNat n, 1 <= n) => (Char -> Bool) -> NonEmptyText n -> Maybe (NonEmptyText n)
 filterNonEmptyText f (NonEmptyText t) = mkNonEmptyText (T.filter f t)
 

--- a/src/Data/StringVariants/NonEmptyText.hs
+++ b/src/Data/StringVariants/NonEmptyText.hs
@@ -87,7 +87,7 @@ filterNonEmptyText :: KnownNat n => (Char -> Bool) -> NonEmptyText n -> Maybe (N
 filterNonEmptyText f (NonEmptyText t) = mkNonEmptyText (T.filter f t)
 
 -- | Narrows the maximum length, dropping any remaining trailing characters.
-takeNonEmptyText :: forall m n. (KnownNat m, KnownNat n, n <= m, 0 <= n) => NonEmptyText m -> NonEmptyText n
+takeNonEmptyText :: forall m n. (KnownNat m, KnownNat n, 1 <= n, n <= m) => NonEmptyText m -> NonEmptyText n
 takeNonEmptyText (NonEmptyText t) =
   if m == n
     then NonEmptyText t
@@ -98,7 +98,7 @@ takeNonEmptyText (NonEmptyText t) =
     n = fromIntegral $ natVal (Proxy @n)
 
 -- | Narrows the maximum length, dropping any prefix remaining characters.
-takeNonEmptyTextEnd :: forall m n. (KnownNat m, KnownNat n, n <= m) => NonEmptyText m -> NonEmptyText n
+takeNonEmptyTextEnd :: forall m n. (KnownNat m, KnownNat n, 1 <= n, n <= m) => NonEmptyText m -> NonEmptyText n
 takeNonEmptyTextEnd (NonEmptyText t) =
   if m == n
     then NonEmptyText t
@@ -113,7 +113,7 @@ takeNonEmptyTextEnd (NonEmptyText t) =
 -- of the input and spacing. Each chunk is stripped of whitespace.
 chunksOfNonEmptyText ::
   forall chunkSize totalSize.
-  (KnownNat chunkSize, KnownNat totalSize) =>
+  (KnownNat chunkSize, KnownNat totalSize, chunkSize <= totalSize) =>
   NonEmptyText totalSize ->
   [NonEmptyText chunkSize]
 chunksOfNonEmptyText (NonEmptyText t) =

--- a/src/Data/StringVariants/NonEmptyText.hs
+++ b/src/Data/StringVariants/NonEmptyText.hs
@@ -34,9 +34,6 @@ module Data.StringVariants.NonEmptyText
     exactLengthRefinedToRange,
     nonEmptyTextFromRefined,
     refinedFromNonEmptyText,
-
-    -- * Convenience util if you need a NonEmptyText of a dynamically determined lengths
-    useNat,
   )
 where
 

--- a/src/Data/StringVariants/NonEmptyText/Internal.hs
+++ b/src/Data/StringVariants/NonEmptyText/Internal.hs
@@ -17,7 +17,7 @@ import Data.MonoTraversable
 import Data.Proxy
 import Data.Sequences
 import Data.String.Conversions (ConvertibleStrings (..), cs)
-import Data.StringVariants.Util (textHasNoMeaningfulContent, textIsTooLong, textIsWhitespace)
+import Data.StringVariants.Util (textHasNoMeaningfulContent, textIsWhitespace)
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
@@ -75,7 +75,7 @@ instance KnownNat n => Arbitrary (NonEmptyText n) where
 
 mkNonEmptyText :: forall n. KnownNat n => Text -> Maybe (NonEmptyText n)
 mkNonEmptyText t
-  | textIsTooLong stripped (fromIntegral $ natVal (Proxy @n)) = Nothing
+  | T.compareLength stripped (fromIntegral $ natVal (Proxy @n)) == GT = Nothing
   | textIsWhitespace stripped = Nothing
   | otherwise = Just (NonEmptyText stripped)
   where

--- a/src/Data/StringVariants/NullableNonEmptyText.hs
+++ b/src/Data/StringVariants/NullableNonEmptyText.hs
@@ -32,7 +32,6 @@ import Data.Aeson.Types qualified as J
 import Data.Data (Proxy (..))
 import Data.Maybe (fromMaybe)
 import Data.StringVariants.NonEmptyText
-import Data.StringVariants.Util (textIsTooLong)
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
@@ -60,7 +59,7 @@ newtype NullableNonEmptyText n = NullableNonEmptyText (Maybe (NonEmptyText n))
 
 mkNullableNonEmptyText :: forall n. KnownNat n => Text -> Maybe (NullableNonEmptyText n)
 mkNullableNonEmptyText t
-  | textIsTooLong t (fromIntegral $ natVal (Proxy @n)) = Nothing -- we can't store text that is too long
+  | T.compareLength t (fromIntegral $ natVal (Proxy @n)) == GT = Nothing -- we can't store text that is too long
   | otherwise = Just $ NullableNonEmptyText $ mkNonEmptyText t
 
 nullNonEmptyText :: NullableNonEmptyText n

--- a/src/Data/StringVariants/NullableNonEmptyText.hs
+++ b/src/Data/StringVariants/NullableNonEmptyText.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Data.StringVariants.NullableNonEmptyText
   ( -- Safe to construct, so we can export the contents
@@ -32,6 +34,7 @@ import Data.Aeson.Types qualified as J
 import Data.Data (Proxy (..))
 import Data.Maybe (fromMaybe)
 import Data.StringVariants.NonEmptyText
+import Data.StringVariants.Util
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
@@ -57,7 +60,7 @@ newtype NullableNonEmptyText n = NullableNonEmptyText (Maybe (NonEmptyText n))
   deriving stock (Generic, Show, Read, Lift)
   deriving newtype (Eq, ToJSON)
 
-mkNullableNonEmptyText :: forall n. KnownNat n => Text -> Maybe (NullableNonEmptyText n)
+mkNullableNonEmptyText :: forall n. (KnownNat n, 1 <= n) => Text -> Maybe (NullableNonEmptyText n)
 mkNullableNonEmptyText t
   | T.compareLength t (fromIntegral $ natVal (Proxy @n)) == GT = Nothing -- we can't store text that is too long
   | otherwise = Just $ NullableNonEmptyText $ mkNonEmptyText t
@@ -68,7 +71,7 @@ nullNonEmptyText = NullableNonEmptyText Nothing
 isNullNonEmptyText :: NullableNonEmptyText n -> Bool
 isNullNonEmptyText = (== nullNonEmptyText)
 
-instance KnownNat n => FromJSON (NullableNonEmptyText n) where
+instance (KnownNat n, 1 <= n) => FromJSON (NullableNonEmptyText n) where
   parseJSON = \case
     J.String t -> case mkNullableNonEmptyText t of
       Just txt -> pure txt
@@ -76,7 +79,7 @@ instance KnownNat n => FromJSON (NullableNonEmptyText n) where
     J.Null -> pure $ NullableNonEmptyText Nothing
     x -> fail $ "Data/StringVariants/NullableNonEmptyText.hs: When trying to parse a NullableNonEmptyText, expected a String or Null, but received: " ++ show x
 
-parseNullableNonEmptyText :: KnownNat n => Text -> J.Object -> J.Parser (NullableNonEmptyText n)
+parseNullableNonEmptyText :: (KnownNat n, 1 <= n) => Text -> J.Object -> J.Parser (NullableNonEmptyText n)
 parseNullableNonEmptyText fieldName obj = obj .:? J.fromText fieldName .!= nullNonEmptyText
 
 fromMaybeNullableText :: Maybe (NullableNonEmptyText n) -> NullableNonEmptyText n
@@ -89,7 +92,7 @@ maybeNonEmptyTextToNullable :: Maybe (NonEmptyText n) -> NullableNonEmptyText n
 maybeNonEmptyTextToNullable Nothing = nullNonEmptyText
 maybeNonEmptyTextToNullable jt = NullableNonEmptyText jt
 
-maybeTextToTruncateNullableNonEmptyText :: forall n. KnownNat n => Maybe Text -> NullableNonEmptyText n
+maybeTextToTruncateNullableNonEmptyText :: forall n. (KnownNat n, 1 <= n) => Maybe Text -> NullableNonEmptyText n
 maybeTextToTruncateNullableNonEmptyText mText = NullableNonEmptyText $ mText >>= mkNonEmptyText . T.take (fromInteger (natVal (Proxy @n)))
 
 nullableNonEmptyTextToMaybeNonEmptyText :: NullableNonEmptyText n -> Maybe (NonEmptyText n)
@@ -108,7 +111,9 @@ compileNullableNonEmptyText n =
     }
   where
     compileNullableNonEmptyText' :: String -> Q Exp
-    compileNullableNonEmptyText' s = useNat n $ \p ->
-      case natOfLength p $ mkNullableNonEmptyText (T.pack s) of
-        Nothing -> fail $ "Invalid NullableNonEmptyText. Needs to be < " ++ show (n + 1) ++ " characters, and not entirely whitespace: " ++ s
+    compileNullableNonEmptyText' s = usePositiveNat n errorMessage $ \(_ :: proxy n) ->
+      case mkNullableNonEmptyText @n (T.pack s) of
         Just txt -> [|$(lift txt)|]
+        Nothing -> errorMessage
+      where
+        errorMessage = fail $ "Invalid NullableNonEmptyText. Needs to be < " ++ show (n + 1) ++ " characters, and not entirely whitespace: " ++ s

--- a/src/Data/StringVariants/Util.hs
+++ b/src/Data/StringVariants/Util.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeOperators #-}
 
-module Data.StringVariants.Util (useNat, usePositiveNat, textIsWhitespace, textHasNoMeaningfulContent) where
+module Data.StringVariants.Util (usePositiveNat, textIsWhitespace, textHasNoMeaningfulContent) where
 
 import Data.Proxy
 import GHC.TypeLits (KnownNat, OrderingI (..), SomeNat (..), cmpNat, someNatVal, type (<=))
@@ -14,11 +14,6 @@ textIsWhitespace = T.all isSpace
 
 textHasNoMeaningfulContent :: Text -> Bool
 textHasNoMeaningfulContent = T.all (\c -> isSpace c || isControl c)
-
-useNat :: Integer -> (forall n proxy. KnownNat n => proxy n -> x) -> x
-useNat n f = case someNatVal n of
-  Nothing -> error (show n ++ " isn't a valid Nat")
-  Just (SomeNat p) -> f p
 
 -- | If the integer is >= 1, evaluate the function with the proof of that. Otherwise, return the default value
 usePositiveNat :: Integer -> a -> (forall n proxy. (KnownNat n, 1 <= n) => proxy n -> a) -> a

--- a/src/Data/StringVariants/Util.hs
+++ b/src/Data/StringVariants/Util.hs
@@ -1,18 +1,9 @@
-module Data.StringVariants.Util (natOfLength, useNat, textIsTooLong, textIsWhitespace, textHasNoMeaningfulContent) where
+module Data.StringVariants.Util (natOfLength, useNat, textIsWhitespace, textHasNoMeaningfulContent) where
 import GHC.TypeLits (KnownNat, Nat, SomeNat (..), someNatVal)
 import Prelude
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Char (isSpace, isControl)
-
-textIsTooLong :: Text -> Int -> Bool
--- why take? because of stream fusion,
--- length isn't O(1), it's O(n). which means
--- it's better to cut off the text at @n@
--- and then evaluate the resulting stream, than
--- to evaluate the entire stream. very unintuitive,
--- but that's just the way things are :(
-textIsTooLong t n = T.length (T.take (n + 1) t) >= (n + 1)
 
 textIsWhitespace :: Text -> Bool
 textIsWhitespace = T.all isSpace

--- a/src/Data/StringVariants/Util.hs
+++ b/src/Data/StringVariants/Util.hs
@@ -1,5 +1,9 @@
-module Data.StringVariants.Util (natOfLength, useNat, textIsWhitespace, textHasNoMeaningfulContent) where
-import GHC.TypeLits (KnownNat, Nat, SomeNat (..), someNatVal)
+{-# LANGUAGE TypeOperators #-}
+
+module Data.StringVariants.Util (useNat, usePositiveNat, textIsWhitespace, textHasNoMeaningfulContent) where
+
+import Data.Proxy
+import GHC.TypeLits (KnownNat, OrderingI (..), SomeNat (..), cmpNat, someNatVal, type (<=))
 import Prelude
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -11,12 +15,16 @@ textIsWhitespace = T.all isSpace
 textHasNoMeaningfulContent :: Text -> Bool
 textHasNoMeaningfulContent = T.all (\c -> isSpace c || isControl c)
 
-
-natOfLength :: proxy (n :: Nat) -> f (other n) -> f (other n)
-natOfLength _ = id
-
 useNat :: Integer -> (forall n proxy. KnownNat n => proxy n -> x) -> x
 useNat n f = case someNatVal n of
   Nothing -> error (show n ++ " isn't a valid Nat")
   Just (SomeNat p) -> f p
 
+-- | If the integer is >= 1, evaluate the function with the proof of that. Otherwise, return the default value
+usePositiveNat :: Integer -> a -> (forall n proxy. (KnownNat n, 1 <= n) => proxy n -> a) -> a
+usePositiveNat n a f = case someNatVal n of
+  Nothing -> a
+  Just (SomeNat p) -> case cmpNat (Proxy @1) p of
+    EQI -> f p
+    LTI -> f p
+    GTI -> a

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -92,6 +92,7 @@ test-suite test
   main-is: Main.hs
   other-modules:
       Spec
+      Specs.NonEmptySpec
       Specs.TextManipulationSpec
       Paths_string_variants
   hs-source-dirs:
@@ -139,9 +140,11 @@ test-suite test
     , aeson >=2.0.0.0
     , base >=4.9 && <5
     , bytestring
+    , hedgehog
     , hspec
     , hspec-core
     , hspec-expectations
+    , hspec-hedgehog
     , mono-traversable
     , refined
     , refinery

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           string-variants
-version:        0.1.0.2
+version:        0.1.1
 synopsis:       Constrained text newtypes
 description:    See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category:       Data

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -77,7 +77,7 @@ library
   build-depends:
       QuickCheck
     , aeson >=2.0.0.0
-    , base >=4.9 && <5
+    , base >=4.16 && <5
     , bytestring
     , mono-traversable
     , refined
@@ -140,7 +140,7 @@ test-suite test
       HUnit
     , QuickCheck
     , aeson >=2.0.0.0
-    , base >=4.9 && <5
+    , base >=4.16 && <5
     , bytestring
     , hedgehog
     , hspec

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           string-variants
-version:        0.1.1
+version:        0.2.0.0
 synopsis:       Constrained text newtypes
 description:    See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category:       Data

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -11,7 +11,7 @@ description:    See README at <https://github.com/MercuryTechnologies/string-var
 category:       Data
 homepage:       https://github.com/MercuryTechnologies/string-variants#readme
 bug-reports:    https://github.com/MercuryTechnologies/string-variants/issues
-maintainer:     Jade Lovelace <jadel@mercury.com>
+maintainer:     Jade Lovelace <jadel@mercury.com>, Borys Lykakh <borys@fastmail.com>
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -83,6 +83,70 @@ library
     , refined
     , refinery
     , string-conversions
+    , template-haskell
+    , text
+  default-language: Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Spec
+      Specs.TextManipulationSpec
+      Paths_string_variants
+  hs-source-dirs:
+      test
+  default-extensions:
+      AllowAmbiguousTypes
+      ApplicativeDo
+      BlockArguments
+      DataKinds
+      DeriveAnyClass
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DerivingVia
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      InstanceSigs
+      LambdaCase
+      MonoLocalBinds
+      MultiWayIf
+      NamedFieldPuns
+      NumericUnderscores
+      OverloadedStrings
+      PatternSynonyms
+      PolyKinds
+      RankNTypes
+      RecordWildCards
+      RecursiveDo
+      ScopedTypeVariables
+      StandaloneDeriving
+      StandaloneKindSignatures
+      TypeApplications
+      TypeFamilies
+      ViewPatterns
+  ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-export-lists -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unused-packages -Wno-missing-kind-signatures -threaded -rtsopts -with-rtsopts=-N -Wno-incomplete-uni-patterns -O0
+  build-depends:
+      HUnit
+    , QuickCheck
+    , aeson >=2.0.0.0
+    , base >=4.9 && <5
+    , bytestring
+    , hspec
+    , hspec-core
+    , hspec-expectations
+    , mono-traversable
+    , refined
+    , refinery
+    , string-conversions
+    , string-variants
     , template-haskell
     , text
   default-language: Haskell2010

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -134,6 +134,8 @@ test-suite test
       TypeFamilies
       ViewPatterns
   ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-export-lists -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unused-packages -Wno-missing-kind-signatures -threaded -rtsopts -with-rtsopts=-N -Wno-incomplete-uni-patterns -O0
+  build-tool-depends:
+      hspec-discover:hspec-discover
   build-depends:
       HUnit
     , QuickCheck

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -16,7 +16,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC ==8.10.7 || ==9.2.4 || ==9.4.2
+    GHC ==9.2.4 || ==9.4.2
 extra-source-files:
     CHANGELOG.md
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,11 @@
+module Main where
+
+import Spec qualified
+import Test.Hspec
+import Test.Hspec.Runner (defaultConfig, hspecWith)
+import Prelude
+
+main :: IO ()
+main =
+  hspecWith defaultConfig $
+    parallel Spec.spec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/test/Specs/NonEmptySpec.hs
+++ b/test/Specs/NonEmptySpec.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Specs.NonEmptySpec (spec) where
+
+import Data.Maybe
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.StringVariants.NonEmptyText
+import Data.StringVariants.NullableNonEmptyText
+import GHC.TypeLits
+import Hedgehog
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Language.Haskell.TH.Quote (QuasiQuoter (quoteExp))
+import Prelude
+import Test.Hspec
+import Test.Hspec.Hedgehog (hedgehog)
+
+mkNonEmptyText299 :: Text -> Maybe (NonEmptyText 299)
+mkNonEmptyText299 = mkNonEmptyText
+
+maybeTextToTruncateNullableNonEmptyText299 :: Maybe Text -> NullableNonEmptyText 299
+maybeTextToTruncateNullableNonEmptyText299 = maybeTextToTruncateNullableNonEmptyText
+
+mkNonEmptyText299WithTruncate :: Text -> Maybe (NonEmptyText 299)
+mkNonEmptyText299WithTruncate = mkNonEmptyTextWithTruncate
+
+matchLength :: proxy (n :: Nat) -> other n -> other n
+matchLength _ = id
+
+spec :: Spec
+spec = describe "NonEmptyText variants" $ do
+  describe "NonEmptyText299" $ do
+    describe "compileNonEmptyText" $ do
+      it "should work" $ do
+        mkNonEmptyText299 "hi" `shouldBe` Just (widen [compileNonEmptyTextKnownLength|hi|])
+    describe "compileNullableNonEmptyText" $ do
+      it "should work" $ do
+        $(quoteExp (compileNullableNonEmptyText 2) "yo") `shouldBe` NullableNonEmptyText (Just [compileNonEmptyTextKnownLength|yo|])
+    describe "nonEmptyTextToText" $ do
+      it "should work" $ do
+        nonEmptyTextToText [compileNonEmptyTextKnownLength|yo|] `shouldBe` "yo"
+
+  describe "Generalized NonEmptyText" $ do
+    describe "mkNonEmptyText" $
+      it "should work" $ do
+        mkNonEmptyText299 "" `shouldBe` Nothing
+        mkNonEmptyText299 " " `shouldBe` Nothing
+        mkNonEmptyText299 "\n" `shouldBe` Nothing
+        mkNonEmptyText299 "\t" `shouldBe` Nothing
+        mkNonEmptyText299 "\NUL" `shouldBe` Nothing
+        mkNonEmptyText299 "x" `shouldSatisfy` isJust
+
+    describe "maybeTextToTruncateNullableNonEmptyText" $ do
+      it "common behavior" $ do
+        maybeTextToTruncateNullableNonEmptyText299 Nothing `shouldBe` NullableNonEmptyText Nothing
+        maybeTextToTruncateNullableNonEmptyText299 (Just "") `shouldBe` NullableNonEmptyText Nothing
+        maybeTextToTruncateNullableNonEmptyText299 (Just " ") `shouldBe` NullableNonEmptyText Nothing
+      it "type-dependent behavior" $
+        hedgehog $ do
+          n <- forAll $ Gen.integral $ Range.constant 1 20000
+          let n' = fromInteger n
+          useNat n $ \p -> do
+            let NullableNonEmptyText mtext =
+                  matchLength p $
+                    maybeTextToTruncateNullableNonEmptyText
+                      (Just $ T.pack $ replicate (n' + 1) 'x')
+            (T.length . nonEmptyTextToText <$> mtext) === Just n'
+
+    describe "mkNonEmptyTextWithTruncate" $ do
+      it "common behavior" $ do
+        mkNonEmptyText299WithTruncate "" `shouldBe` Nothing
+        mkNonEmptyText299WithTruncate " " `shouldBe` Nothing
+      it "type-dependent behavior" $
+        hedgehog $ do
+          n <- forAll $ Gen.integral $ Range.constant 1 20000
+          let n' = fromInteger n
+          useNat n $ \p -> do
+            let mtext = natOfLength p $ mkNonEmptyTextWithTruncate (T.pack $ replicate (n' + 1) 'x')
+            (T.length . nonEmptyTextToText <$> mtext) === Just n'

--- a/test/Specs/NonEmptySpec.hs
+++ b/test/Specs/NonEmptySpec.hs
@@ -8,6 +8,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.StringVariants.NonEmptyText
 import Data.StringVariants.NullableNonEmptyText
+import Data.StringVariants.Util (usePositiveNat)
 import GHC.TypeLits
 import Hedgehog
 import Hedgehog.Gen qualified as Gen
@@ -61,7 +62,7 @@ spec = describe "NonEmptyText variants" $ do
         hedgehog $ do
           n <- forAll $ Gen.integral $ Range.constant 1 20000
           let n' = fromInteger n
-          useNat n $ \p -> do
+          usePositiveNat n (pure ()) $ \p -> do
             let NullableNonEmptyText mtext =
                   matchLength p $
                     maybeTextToTruncateNullableNonEmptyText
@@ -76,6 +77,6 @@ spec = describe "NonEmptyText variants" $ do
         hedgehog $ do
           n <- forAll $ Gen.integral $ Range.constant 1 20000
           let n' = fromInteger n
-          useNat n $ \p -> do
-            let mtext = natOfLength p $ mkNonEmptyTextWithTruncate (T.pack $ replicate (n' + 1) 'x')
+          usePositiveNat n (pure ()) $ \(_ :: proxy n) -> do
+            let mtext = mkNonEmptyTextWithTruncate @n (T.pack $ replicate (n' + 1) 'x')
             (T.length . nonEmptyTextToText <$> mtext) === Just n'

--- a/test/Specs/TextManipulationSpec.hs
+++ b/test/Specs/TextManipulationSpec.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Specs.TextManipulationSpec (spec) where
+
+import Data.Char
+import Data.StringVariants.NonEmptyText
+import Test.Hspec
+import Prelude
+
+spec :: Spec
+spec = describe "Text manipulation" do
+  describe "filterNonEmptyText" $ do
+    it "filterNonEmptyText returns Nothing when filtered string is empty" do
+      filterNonEmptyText (const False) [compileNonEmptyTextKnownLength|abc|] `shouldBe` Nothing
+
+    it "filterNonEmptyText returns Nothing when filtered string only has spaces" do
+      filterNonEmptyText isSpace [compileNonEmptyTextKnownLength|a b|] `shouldBe` Nothing
+
+    it "filterNonEmptyText returns stripped text" do
+      filterNonEmptyText (/= 'a') [compileNonEmptyTextKnownLength|a b a|] `shouldBe` Just (widen [compileNonEmptyTextKnownLength|b|])
+
+  describe "takeNonEmptyText" $ do
+    it "takeNonEmptyText returns stripped text" do
+      -- taking two characters results in a trailing space
+      takeNonEmptyText [compileNonEmptyTextKnownLength|a b|] `shouldBe` (widen [compileNonEmptyTextKnownLength|a|] :: NonEmptyText 2)
+
+  describe "takeNonEmptyTextEnd" $ do
+    it "takeNonEmptyTextEnd returns stripped text" do
+      -- taking two characters results in a leading space
+      takeNonEmptyTextEnd [compileNonEmptyTextKnownLength|a b|] `shouldBe` (widen [compileNonEmptyTextKnownLength|b|] :: NonEmptyText 2)
+
+  describe "chunksOfNonEmptyText" $ do
+    it "chunksOfNonEmptyText drops empty chunks" $ do
+      chunksOfNonEmptyText [compileNonEmptyTextKnownLength|a   b|]
+        `shouldBe` ([[compileNonEmptyTextKnownLength|a|], [compileNonEmptyTextKnownLength|b|]] :: [NonEmptyText 1])
+    it "chunksOfNonEmptyText strips chunks" $ do
+      chunksOfNonEmptyText [compileNonEmptyTextKnownLength|a   b|]
+        `shouldBe` ([widen [compileNonEmptyTextKnownLength|a|], widen [compileNonEmptyTextKnownLength|b|]] :: [NonEmptyText 2])


### PR DESCRIPTION
The text manipulation functions let us create invalid `NonEmptyText`. The output of manipulation would be stripped or rejected by `mkNonEmptyText`.

```
ghci> filterNonEmptyText (const False) $ fromJust (mkNonEmptyText "aa" :: Maybe (NonEmptyText 10))
NonEmptyText ""
ghci> (takeNonEmptyText $ fromJust (mkNonEmptyText "aa" :: Maybe (NonEmptyText 10))) :: NonEmptyText 0
NonEmptyText ""
ghci> filterNonEmptyText (not . isAlpha) $ fromJust (mkNonEmptyText "a  b" :: Maybe (NonEmptyText 10))
NonEmptyText "  "
```

This change fixes the issues and adds a test suite. The changes are breaking, so the major version gets bumped to `0.2.0.0`.