### PR TITLE
Type-level creation of string variants

### DIFF
--- a/src/Data/StringVariants/NonEmptyText.hs
+++ b/src/Data/StringVariants/NonEmptyText.hs
@@ -13,6 +13,7 @@ module Data.StringVariants.NonEmptyText
     -- * Construction
     mkNonEmptyText,
     mkNonEmptyTextWithTruncate,
+    literalNonEmptyText,
     unsafeMkNonEmptyText,
     nonEmptyTextToText,
     compileNonEmptyText,
@@ -46,7 +47,7 @@ import Data.StringVariants.Util
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
-import GHC.TypeLits (KnownNat, natVal, type (+), type (<=))
+import GHC.TypeLits (KnownNat, KnownSymbol, Symbol, Nat, natVal, symbolVal, type (+), type (<=))
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax (Lift (..))
@@ -71,6 +72,8 @@ compileNonEmptyText n =
       where
         errorMessage = fail $ "Invalid NonEmptyText. Needs to be < " ++ show (n + 1) ++ " characters, and not entirely whitespace: " ++ s
 
+literalNonEmptyText :: forall (s :: Symbol) (n :: Nat). (KnownSymbol s, KnownNat n, SymbolNonEmpty s, SymbolWithNoSpaceAround s, SymbolNoLongerThan s n) => NonEmptyText n
+literalNonEmptyText = NonEmptyText (T.pack (symbolVal (Proxy @s)))
 
 convertEmptyTextToNothing :: Text -> Maybe Text
 convertEmptyTextToNothing t

--- a/src/Data/StringVariants/NullableNonEmptyText.hs
+++ b/src/Data/StringVariants/NullableNonEmptyText.hs
@@ -9,6 +9,7 @@ module Data.StringVariants.NullableNonEmptyText
     -- * Constructing
     mkNonEmptyTextWithTruncate,
     compileNullableNonEmptyText,
+    literalNullableNonEmptyText,
     mkNullableNonEmptyText,
     parseNullableNonEmptyText,
     nullNonEmptyText,
@@ -38,7 +39,7 @@ import Data.StringVariants.Util
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
-import GHC.TypeLits (KnownNat, natVal)
+import GHC.TypeLits (KnownNat, KnownSymbol, Nat, Symbol, natVal)
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax (Lift (..))
@@ -117,3 +118,7 @@ compileNullableNonEmptyText n =
         Nothing -> errorMessage
       where
         errorMessage = fail $ "Invalid NullableNonEmptyText. Needs to be < " ++ show (n + 1) ++ " characters, and not entirely whitespace: " ++ s
+
+-- | This requires the text to be non-empty. For the empty text just use the constructor `NullableNonEmptyText Nothing`
+literalNullableNonEmptyText :: forall (s :: Symbol) (n :: Nat). (KnownSymbol s, KnownNat n, SymbolNonEmpty s, SymbolWithNoSpaceAround s, SymbolNoLongerThan s n) => NullableNonEmptyText n
+literalNullableNonEmptyText = NullableNonEmptyText (Just (literalNonEmptyText @s @n))

--- a/src/Data/StringVariants/Prose.hs
+++ b/src/Data/StringVariants/Prose.hs
@@ -3,6 +3,7 @@ module Data.StringVariants.Prose
   ( Prose,
     mkProse,
     compileProse,
+    literalProse,
     proseToText,
   )
 where

--- a/src/Data/StringVariants/Prose/Internal.hs
+++ b/src/Data/StringVariants/Prose/Internal.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 
+-- GHC considers the constraints for the prose symbol redundant.
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
 -- | Internal module of Prose, allowing breaking the abstraction.
 --
 --   Prefer to use "Data.StringVariants.Prose" instead.
@@ -8,9 +11,12 @@ module Data.StringVariants.Prose.Internal where
 import Data.Aeson (FromJSON, ToJSON, ToJSONKey, withText)
 import Data.Aeson.Types (FromJSON (..))
 import Data.String.Conversions (ConvertibleStrings (..), cs)
+import Data.StringVariants.Util (SymbolWithNoSpaceAround)
+import Data.Proxy
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
+import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax
 import Prelude
@@ -54,6 +60,9 @@ compileProse =
       Just s' -> [|$(lift s')|]
 
     msg s = "Invalid Prose: " <> s <> ". Make sure you aren't wrapping the text in quotes."
+
+literalProse :: forall (s :: Symbol). (KnownSymbol s, SymbolWithNoSpaceAround s) => Prose
+literalProse = Prose (T.pack (symbolVal (Proxy @s)))
 
 proseToText :: Prose -> Text
 proseToText (Prose txt) = txt

--- a/src/Data/StringVariants/Util.hs
+++ b/src/Data/StringVariants/Util.hs
@@ -38,7 +38,7 @@ type IsCharWhitespace c
     (CharToNat c == 32 || CharToNat c - 0x9 <=? 4 || CharToNat c == 0xa0)
     (IsUnicodeWhitespaceCodePoint (CharToNat c))
 
--- Unicode characters with property White_Space=yes and above the ASCII range. It compares whitespace characters are for Unicode 15.0.0.
+-- It checks the whitespace characters (Unicode property White_Space=yes) defined in Unicode 15.0.0 and above the ASCII range.
 type IsUnicodeWhitespaceCodePoint n
   = n == 0x1680
   || (0x2000 <=? n && n <=? 0x200A)

--- a/src/Data/StringVariants/Util.hs
+++ b/src/Data/StringVariants/Util.hs
@@ -1,9 +1,15 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
-module Data.StringVariants.Util (usePositiveNat, textIsWhitespace, textHasNoMeaningfulContent) where
+module Data.StringVariants.Util (SymbolNonEmpty, SymbolWithNoSpaceAround, SymbolNoLongerThan, usePositiveNat, textIsWhitespace, textHasNoMeaningfulContent) where
 
 import Data.Proxy
-import GHC.TypeLits (KnownNat, OrderingI (..), SomeNat (..), cmpNat, someNatVal, type (<=))
+import Data.Kind (Constraint)
+import Data.Type.Bool
+import Data.Type.Equality
+import GHC.TypeError
+import GHC.TypeLits
 import Prelude
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -23,3 +29,38 @@ usePositiveNat n a f = case someNatVal n of
     EQI -> f p
     LTI -> f p
     GTI -> a
+
+-- Logic ported from base-4.17 Data.Char.isSpace.
+-- Hopefully, GHC would add this type-level function
+type IsCharWhitespace c
+  = If
+    (CharToNat c <=? 0x376)
+    (CharToNat c == 32 || CharToNat c - 0x9 <=? 4 || CharToNat c == 0xa0)
+    (IsUnicodeWhitespaceCodePoint (CharToNat c))
+
+-- Unicode characters with property White_Space=yes and above the ASCII range. It compares whitespace characters are for Unicode 15.0.0.
+type IsUnicodeWhitespaceCodePoint n
+  = n == 0x1680
+  || (0x2000 <=? n && n <=? 0x200A)
+  || n == 0x2028 || n == 0x2029 || n == 0x202F || n == 0x205F || n == 0x3000
+
+type family SymbolLength (length :: Nat) (s :: Maybe (Char, Symbol)) :: Nat where
+  SymbolLength length 'Nothing = length
+  SymbolLength length ('Just '(_, s)) = SymbolLength (length + 1) (UnconsSymbol s)
+
+type SymbolNonEmpty s = If (s == "") (TypeError ('Text "Symbol is empty")) (() :: Constraint)
+
+type family SymbolNoLeadingSpace (s :: Maybe (Char, Symbol)) :: Constraint where
+  SymbolNoLeadingSpace 'Nothing = ()
+  SymbolNoLeadingSpace ('Just '(c, _)) = If (IsCharWhitespace c) (TypeError ('Text "Symbol has leading whitespace")) (() :: Constraint)
+
+type family SymbolNoTrailingSpace (s :: Maybe (Char, Symbol)) :: Constraint where
+  SymbolNoTrailingSpace 'Nothing = ()
+  SymbolNoTrailingSpace ('Just '(c, "")) = If (IsCharWhitespace c) (TypeError ('Text "Symbol has trailing whitespace")) (() :: Constraint)
+  SymbolNoTrailingSpace ('Just '(_, s)) = SymbolNoTrailingSpace (UnconsSymbol s)
+
+-- The type family IsCharWhitespace is large but it is only evaluated for the first and last symbols
+type SymbolWithNoSpaceAround s = (SymbolNoLeadingSpace (UnconsSymbol s), SymbolNoTrailingSpace (UnconsSymbol s)) 
+
+type SymbolNoLongerThan s n = Assert (SymbolLength 0 (UnconsSymbol s) <=? n)
+  (TypeError ('Text "Invalid NonEmptyText. Needs to be <= " ':<>: 'ShowType n ':<>: 'Text " characters. Has " ':<>: 'ShowType (SymbolLength 0 (UnconsSymbol s)) ':<>: 'Text " characters."))

--- a/src/Data/StringVariants/Util.hs
+++ b/src/Data/StringVariants/Util.hs
@@ -8,7 +8,6 @@ import Data.Proxy
 import Data.Kind (Constraint)
 import Data.Type.Bool
 import Data.Type.Equality
-import GHC.TypeError
 import GHC.TypeLits
 import Prelude
 import Data.Text (Text)
@@ -62,5 +61,6 @@ type family SymbolNoTrailingSpace (s :: Maybe (Char, Symbol)) :: Constraint wher
 -- The type family IsCharWhitespace is large but it is only evaluated for the first and last symbols
 type SymbolWithNoSpaceAround s = (SymbolNoLeadingSpace (UnconsSymbol s), SymbolNoTrailingSpace (UnconsSymbol s)) 
 
-type SymbolNoLongerThan s n = Assert (SymbolLength 0 (UnconsSymbol s) <=? n)
+type SymbolNoLongerThan s n = If (SymbolLength 0 (UnconsSymbol s) <=? n)
+  (() :: Constraint)
   (TypeError ('Text "Invalid NonEmptyText. Needs to be <= " ':<>: 'ShowType n ':<>: 'Text " characters. Has " ':<>: 'ShowType (SymbolLength 0 (UnconsSymbol s)) ':<>: 'Text " characters."))

--- a/src/Data/StringVariants/Util.hs
+++ b/src/Data/StringVariants/Util.hs
@@ -47,7 +47,9 @@ type family SymbolLength (length :: Nat) (s :: Maybe (Char, Symbol)) :: Nat wher
   SymbolLength length 'Nothing = length
   SymbolLength length ('Just '(_, s)) = SymbolLength (length + 1) (UnconsSymbol s)
 
-type SymbolNonEmpty s = If (s == "") (TypeError ('Text "Symbol is empty")) (() :: Constraint)
+type family SymbolNonEmpty (s :: Symbol) :: Constraint where
+  SymbolNonEmpty "" = TypeError ('Text "Symbol is empty")
+  SymbolNonEmpty _ = ()
 
 type family SymbolNoLeadingSpace (s :: Maybe (Char, Symbol)) :: Constraint where
   SymbolNoLeadingSpace 'Nothing = ()
@@ -61,6 +63,7 @@ type family SymbolNoTrailingSpace (s :: Maybe (Char, Symbol)) :: Constraint wher
 -- The type family IsCharWhitespace is large but it is only evaluated for the first and last symbols
 type SymbolWithNoSpaceAround s = (SymbolNoLeadingSpace (UnconsSymbol s), SymbolNoTrailingSpace (UnconsSymbol s)) 
 
-type SymbolNoLongerThan s n = If (SymbolLength 0 (UnconsSymbol s) <=? n)
-  (() :: Constraint)
-  (TypeError ('Text "Invalid NonEmptyText. Needs to be <= " ':<>: 'ShowType n ':<>: 'Text " characters. Has " ':<>: 'ShowType (SymbolLength 0 (UnconsSymbol s)) ':<>: 'Text " characters."))
+type family SymbolNoLongerThan (s :: Symbol) (n :: Nat) :: Constraint where
+  SymbolNoLongerThan s n = If (SymbolLength 0 (UnconsSymbol s) <=? n)
+    (() :: Constraint)
+    (TypeError ('Text "Invalid NonEmptyText. Needs to be <= " ':<>: 'ShowType n ':<>: 'Text " characters. Has " ':<>: 'ShowType (SymbolLength 0 (UnconsSymbol s)) ':<>: 'Text " characters."))

--- a/test/Specs/NonEmptySpec.hs
+++ b/test/Specs/NonEmptySpec.hs
@@ -57,6 +57,25 @@ spec = describe "NonEmptyText variants" $ do
       it "should work" $ do
         Just (literalNonEmptyText @"abc def") `shouldBe` mkNonEmptyText299 "abc def"
 
+-- test cases for bad strings. Alas, the -fdefer-type-errors defers the errors but then happily creates invalid values in runtime. Is this a GHC bug?
+
+      -- describe "rejects invalid strings" $ do
+      --   it "rejects string too long" $ do
+      --     print (literalNonEmptyText @"abcdefghijkl" :: NonEmptyText 10)
+      --       `shouldThrow` (("Invalid NonEmptyText. Needs to be <= 10 characters. Has 12 characters." `isInfixOf`) . show)
+      --   it "rejects empty string" $ do
+      --     print (literalNonEmptyText @"" :: NonEmptyText 10)
+      --       `shouldThrow` (("Symbol is empty" `isInfixOf`) . show)
+      --   it "rejects string with leading whitespace" $ do
+      --     print (literalNonEmptyText @" abc" :: NonEmptyText 10)
+      --       `shouldThrow` (("Symbol has leading whitespace" `isInfixOf`) . show)
+      --   it "rejects string with trailing whitespace" $ do
+      --     print (literalNonEmptyText @"abc " :: NonEmptyText 10)
+      --       `shouldThrow` (("Symbol has leading whitespace" `isInfixOf`) . show)
+      --   it "rejects string with leading unicode whitespace" $ do
+      --     print (literalNonEmptyText @"\x2000abc" :: NonEmptyText 10)
+      --       `shouldThrow` (("Symbol has leading whitespace" `isInfixOf`) . show)
+
     describe "maybeTextToTruncateNullableNonEmptyText" $ do
       it "common behavior" $ do
         maybeTextToTruncateNullableNonEmptyText299 Nothing `shouldBe` NullableNonEmptyText Nothing

--- a/test/Specs/NonEmptySpec.hs
+++ b/test/Specs/NonEmptySpec.hs
@@ -53,6 +53,10 @@ spec = describe "NonEmptyText variants" $ do
         mkNonEmptyText299 "\NUL" `shouldBe` Nothing
         mkNonEmptyText299 "x" `shouldSatisfy` isJust
 
+    describe "literalNonEmptyText" $ do
+      it "should work" $ do
+        Just (literalNonEmptyText @"abc def") `shouldBe` mkNonEmptyText299 "abc def"
+
     describe "maybeTextToTruncateNullableNonEmptyText" $ do
       it "common behavior" $ do
         maybeTextToTruncateNullableNonEmptyText299 Nothing `shouldBe` NullableNonEmptyText Nothing


### PR DESCRIPTION
This adds functions `literalNonEmptyText`, `literalNullableNonEmptyText` and `literalProse` to create string variants from the statically known strings. Unlike `compileNonEmptyText`, which strips the string before creating a `NonEmptyText`, the `literalNonEmptyText` does not change the string. Instead it uses the type-level constraints to validate it.

This change allows us to use the standard Haskell type system over a quasi-quotation syntax. For the modules that heavily use `compileNonEmptyText` to create `NonEmptyText`, switching from Template Haskell the type-level function `literalNonEmptyText` would also speed up compilation.

Another ergonomic improvement is that the length of the NonEmptyText can be inferred. In comparison, `compileNonEmptyText` must be explicitly passed the length.

### Switching to type-level functions

``` haskell
module StringHelpers where
compileNonEmptyText10, compileNonEmptyText299 :: QuasiQuoter
compileNonEmptyText10 = compileNonEmptyText 10
compileNonEmptyText299 = compileNonEmptyText 299

module Another where
import StringHelpers
...
f :: NonEmptyText 10 -> NonEmptyText 299 -> IO ()
f = ...

f [compileNonEmptyText10|abc|] [compileNonEmptyText299|def|]
```


``` haskell
-- No need to define a quasi-quoter for each length.
module Another where
...
f :: NonEmptyText 10 -> NonEmptyText 299 -> IO ()
f = ...

f (literalNonEmptyText @"abc") (literalNonEmptyText @"def")
```

### Examples
```
ghci> literalNonEmptyText @"abcdefghij" :: NonEmptyText 10
NonEmptyText "abcdefghij"

ghci> literalNonEmptyText @"abcdefghijkl" :: NonEmptyText 10
<interactive>:5:1: error:
    • Invalid NonEmptyText. Needs to be <= 10 characters. Has 12 characters.
    • In the expression:
          literalNonEmptyText @"abcdefghijkl" :: NonEmptyText 10
      In an equation for ‘it’:
          it = literalNonEmptyText @"abcdefghijkl" :: NonEmptyText 10

ghci> literalNonEmptyText @"" :: NonEmptyText 10
<interactive>:3:1: error:
    • Symbol is empty
    • In the expression: literalNonEmptyText @"" :: NonEmptyText 10
      In an equation for ‘it’:
          it = literalNonEmptyText @"" :: NonEmptyText 10

-- Includes a trailing whitespace from Unicode above ASCII
ghci> literalNonEmptyText @" aaa\x2000" :: NonEmptyText 10
<interactive>:2:1: error:
    • Symbol has trailing whitespace
    • In the expression:
          literalNonEmptyText @" aaa\x2000" :: NonEmptyText 10
      In an equation for ‘it’:
          it = literalNonEmptyText @" aaa\x2000" :: NonEmptyText 10

<interactive>:2:1: error:
    • Symbol has leading whitespace
    • In the expression:
          literalNonEmptyText @" aaa\x2000" :: NonEmptyText 10
      In an equation for ‘it’:
          it = literalNonEmptyText @" aaa\x2000" :: NonEmptyText 10
```