### PR TITLE
chunks of nonempty as a nonempty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.1.0] - 2023-01-23
+
+- Use `NonEmptyList` for `chunksOfNonEmptyText`
+
 ## [0.2.0.0] - 2022-12-05
 
 - Add `literalNonEmptyText`, `literalProse`, `literalNullableNonEmptyText` for creation of string variants from the type-level literals.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: string-variants
-version: 0.2.0.0
+version: 0.2.1.0
 synopsis: Constrained text newtypes
 description: See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category: Data

--- a/src/Data/StringVariants/NonEmptyText.hs
+++ b/src/Data/StringVariants/NonEmptyText.hs
@@ -123,11 +123,13 @@ chunksOfNonEmptyText ::
   NonEmptyText totalSize ->
   NE.NonEmpty (NonEmptyText chunkSize)
 chunksOfNonEmptyText (NonEmptyText t) =
-  -- NE.fromList is partial. However, since we know the input
-  -- is nonempty, we're guaranteed to get at least one nonempty
-  -- chunk.
-  NE.fromList $ mapMaybe mkNonEmptyText (T.chunksOf chunkSize t)
+  case mNonEmptyChunks of
+    Nothing -> error $ "chunksOfNonEmptyText: invalid input: " <> show t
+    Just chunks -> chunks
   where
+    -- The function NE.nonEmpty is safer than partial NE.fromList.
+    -- If the input NonEmptyText is invalid, we want to return a detailed error message.
+    mNonEmptyChunks = NE.nonEmpty $ mapMaybe mkNonEmptyText (T.chunksOf chunkSize t)
     chunkSize = fromIntegral $ natVal (Proxy @chunkSize)
 
 -- | Concat two NonEmptyText values, with the new maximum length being the sum of the two

--- a/src/Data/StringVariants/NonEmptyText.hs
+++ b/src/Data/StringVariants/NonEmptyText.hs
@@ -41,6 +41,7 @@ where
 
 import Control.Monad
 import Data.Data (Proxy (..), typeRep)
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (mapMaybe)
 import Data.StringVariants.NonEmptyText.Internal
 import Data.StringVariants.Util
@@ -120,9 +121,12 @@ chunksOfNonEmptyText ::
   forall chunkSize totalSize.
   (KnownNat chunkSize, KnownNat totalSize, chunkSize <= totalSize, 1 <= chunkSize) =>
   NonEmptyText totalSize ->
-  [NonEmptyText chunkSize]
+  NE.NonEmpty (NonEmptyText chunkSize)
 chunksOfNonEmptyText (NonEmptyText t) =
-  mapMaybe mkNonEmptyText (T.chunksOf chunkSize t)
+  -- NE.fromList is partial. However, since we know the input
+  -- is nonempty, we're guaranteed to get at least one nonempty
+  -- chunk.
+  NE.fromList $ mapMaybe mkNonEmptyText (T.chunksOf chunkSize t)
   where
     chunkSize = fromIntegral $ natVal (Proxy @chunkSize)
 

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           string-variants
-version:        0.2.0.0
+version:        0.2.1.0
 synopsis:       Constrained text newtypes
 description:    See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category:       Data

--- a/test/Specs/TextManipulationSpec.hs
+++ b/test/Specs/TextManipulationSpec.hs
@@ -3,6 +3,7 @@
 module Specs.TextManipulationSpec (spec) where
 
 import Data.Char
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.StringVariants.NonEmptyText
 import Test.Hspec
 import Prelude
@@ -32,7 +33,7 @@ spec = describe "Text manipulation" do
   describe "chunksOfNonEmptyText" $ do
     it "chunksOfNonEmptyText drops empty chunks" $ do
       chunksOfNonEmptyText [compileNonEmptyTextKnownLength|a   b|]
-        `shouldBe` ([[compileNonEmptyTextKnownLength|a|], [compileNonEmptyTextKnownLength|b|]] :: [NonEmptyText 1])
+        `shouldBe` ([compileNonEmptyTextKnownLength|a|] :| [[compileNonEmptyTextKnownLength|b|]] :: NonEmpty (NonEmptyText 1))
     it "chunksOfNonEmptyText strips chunks" $ do
       chunksOfNonEmptyText [compileNonEmptyTextKnownLength|a   b|]
-        `shouldBe` ([widen [compileNonEmptyTextKnownLength|a|], widen [compileNonEmptyTextKnownLength|b|]] :: [NonEmptyText 2])
+        `shouldBe` (widen [compileNonEmptyTextKnownLength|a|] :| [widen [compileNonEmptyTextKnownLength|b|]] :: NonEmpty (NonEmptyText 2))


### PR DESCRIPTION
I added this function to mwb in a recent PR but it probably belongs here. When we do `chunksOfNonEmptyText` we're guaranteed to get at least one chunk, so here's a version that returns a nonempty list.

Though it uses `fromJust` and so deserves skepticism, I've thought it through and I think it's safe. Please think it through with me and let me know if you think there are any holes. Also open to suggestions for better test cases; I just repeated the ones from `chunksOfNonEmptyText`.
