### PR TITLE
Update flake GHC to 9.2.4, use hackage version of refined

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,3 @@
 -- HI! for pants reasons, if you add anything load bearing in here, you have to
 -- add it to raw-project in cabal.haskell-ci
 packages: .
-
--- https://github.com/nikita-volkov/refined/pull/86
--- this was merged, just need to wait for >0.7  to have a release
-source-repository-package
-  type: git
-  location: https://github.com/nikita-volkov/refined
-  tag: eced2bb0991bde971646e4b3d291870d0aab83a3
-  --sha256: sha256-QvZSFeAmgdBwdyneGRKMCMNGnP+8rD/uTED0icQB+4s=

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     let
-      ghcVer = "ghc902";
+      ghcVer = "ghc924";
       makeHaskellOverlay = overlay: final: prev: {
         haskell = prev.haskell // {
           packages = prev.haskell.packages // {


### PR DESCRIPTION
The minimum requirement for base was bumped to 9.2. This updates the flake.

Also, refined 0.8 was released on hackage, so taking it from git is no longer necessary