### PR TITLE
Version 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.2.1] - 2023-06-20
+
+- Add support for `aeson-2.2.0.0`.
+- When built with `aeson >=2.2.0.0`, record fields with type `NullableNonEmptyText` will be omittable.
+
 ## [0.2.2.0] - 2023-02-10
 
 - Add `proseFromNonEmptyText` to create `Prose` from `NonEmptyText`.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ This library provides newtypes of Text for use in application code:
 
 - `NonEmptyText`: a not-empty not-completely-whitespace, length limited newtype
   over Text
-- `NullableNonEmptyText`: a NonEmptyText that may be empty or absent. This is
-  used for JSON parsing as `Maybe NullableNonEmptyText`.
+- `NullableNonEmptyText`: a NonEmptyText that may be empty, totally whitespace,
+  or even null while still successfully parsing as `NullableNonEmptyText Nothing`.
+  As of `aeson-2.2.0.0`, fields of this type are optional for records using a
+  `Data.Aeson.Options` with `omitNothingFields == True`.
+  If using `aeson <2.2.0.0`, use `Maybe NullableNonEmptyText` if you want the
+  field to be optional.
 - `Prose`: a whitespace-stripped newtype over Text
 
 This library is not API stable or fully documented yet, however it is

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: string-variants
-version: 0.2.2.0
+version: 0.2.2.1
 synopsis: Constrained text newtypes
 description: See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category: Data

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           string-variants
-version:        0.2.1.0
+version:        0.2.2.1
 synopsis:       Constrained text newtypes
 description:    See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category:       Data


### PR DESCRIPTION
* Adds support for aeson-2.2.0.0

* NullableNonEmptyText is now optional as a field when built with aeson >=2.2.0.0