### PR TITLE
Remove `Semigroup` instance for `NonEmptyText`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.0.0] - 2023-10-24
+
+- Remove incorrect `Semigroup` instance for `NonEmptyText`
+
 ## [0.2.2.1] - 2023-06-20
 
 - Add support for `aeson-2.2.0.0`.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: string-variants
-version: 0.2.2.1
+version: 0.3.0.0
 synopsis: Constrained text newtypes
 description: See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category: Data

--- a/src/Data/StringVariants/NonEmptyText/Internal.hs
+++ b/src/Data/StringVariants/NonEmptyText/Internal.hs
@@ -22,7 +22,7 @@ import Data.StringVariants.Util (textHasNoMeaningfulContent, textIsWhitespace)
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
-import GHC.TypeLits (KnownNat, Nat, natVal, type (<=))
+import GHC.TypeLits (ErrorMessage (..), KnownNat, Nat, TypeError, natVal, type (<=))
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax (Lift (..), TyLit (..), Type (..))
 import Test.QuickCheck
@@ -73,6 +73,15 @@ instance (KnownNat n, 1 <= n) => Arbitrary (NonEmptyText n) where
       -- Mostly alphanumeric characters, all human readable
       str <- replicateM size $ elements ['0' .. 'z']
       pure $ T.pack str
+
+instance
+  TypeError
+        ( 'Text "An instance of 'Semigroup (NonEmptyText n)' would violate the "
+    ':<>: 'Text "length guarantees."
+    ':$$: 'Text "Please use '(<>|)' or 'concatWithSpace' to combine the values."
+        )
+  => Semigroup (NonEmptyText n) where
+  (<>) = error "unreachable"
 
 mkNonEmptyText :: forall n. (KnownNat n, 1 <= n) => Text -> Maybe (NonEmptyText n)
 mkNonEmptyText t

--- a/src/Data/StringVariants/NonEmptyText/Internal.hs
+++ b/src/Data/StringVariants/NonEmptyText/Internal.hs
@@ -31,7 +31,7 @@ import Prelude
 -- | Non Empty Text, requires the input is between 1 and @n@ chars and not just whitespace.
 newtype NonEmptyText (n :: Nat) = NonEmptyText Text
   deriving stock (Generic, Show, Read, Lift)
-  deriving newtype (Eq, Ord, ToJSON, Semigroup, MonoFoldable)
+  deriving newtype (Eq, Ord, ToJSON, MonoFoldable)
 
 type instance Element (NonEmptyText _n) = Char
 

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           string-variants
-version:        0.2.2.1
+version:        0.3.0.0
 synopsis:       Constrained text newtypes
 description:    See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category:       Data


### PR DESCRIPTION
It's incorrect:

```
ghci> import Data.StringVariants.NonEmptyText
ghci> let x = literalNonEmptyText @"foo" :: NonEmptyText 3
    |
ghci> let y = literalNonEmptyText @"bar" :: NonEmptyText 3
    |
ghci> :t x <> y
x <> y :: NonEmptyText 3
ghci> show (x <> y)
"NonEmptyText "foobar""
```