### PR TITLE
Fix GHC warnings

### DIFF
--- a/src/Data/StringVariants/NonEmptyText/Internal.hs
+++ b/src/Data/StringVariants/NonEmptyText/Internal.hs
@@ -77,8 +77,8 @@ instance (KnownNat n, 1 <= n) => Arbitrary (NonEmptyText n) where
 instance
   TypeError
         ( 'Text "An instance of 'Semigroup (NonEmptyText n)' would violate the "
-    ':<>: 'Text "length guarantees."
-    ':$$: 'Text "Please use '(<>|)' or 'concatWithSpace' to combine the values."
+    ' :<>: 'Text "length guarantees."
+    ' :$$: 'Text "Please use '(<>|)' or 'concatWithSpace' to combine the values."
         )
   => Semigroup (NonEmptyText n) where
   (<>) = error "unreachable"

--- a/src/Data/StringVariants/Util.hs
+++ b/src/Data/StringVariants/Util.hs
@@ -66,4 +66,4 @@ type SymbolWithNoSpaceAround s = (SymbolNoLeadingSpace (UnconsSymbol s), SymbolN
 type family SymbolNoLongerThan (s :: Symbol) (n :: Nat) :: Constraint where
   SymbolNoLongerThan s n = If (SymbolLength 0 (UnconsSymbol s) <=? n)
     (() :: Constraint)
-    (TypeError ('Text "Invalid NonEmptyText. Needs to be <= " ':<>: 'ShowType n ':<>: 'Text " characters. Has " ':<>: 'ShowType (SymbolLength 0 (UnconsSymbol s)) ':<>: 'Text " characters."))
+    (TypeError ('Text "Invalid NonEmptyText. Needs to be <= " ' :<>: 'ShowType n ' :<>: 'Text " characters. Has " ' :<>: 'ShowType (SymbolLength 0 (UnconsSymbol s)) ' :<>: 'Text " characters."))


### PR DESCRIPTION
Separating a tick with a whitespace looks weird but that's what GHC wants.