### PR TITLE
Add Data instance to NonEmptyText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.1.0] - 2024-02-29
+
+- Add `Data` instance to `NonEmptyText`.
+
 ## [0.3.0.1] - 2024-01-03
 
 - Add support for GHC 9.6

--- a/src/Data/StringVariants/NonEmptyText/Internal.hs
+++ b/src/Data/StringVariants/NonEmptyText/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -14,6 +15,7 @@ import Control.Monad (when)
 import Data.Aeson (FromJSON (..), ToJSON, withText)
 import Data.ByteString
 import Data.Coerce
+import Data.Data (Data)
 import Data.MonoTraversable
 import Data.Proxy
 import Data.Sequences
@@ -30,7 +32,7 @@ import Prelude
 
 -- | Non Empty Text, requires the input is between 1 and @n@ chars and not just whitespace.
 newtype NonEmptyText (n :: Nat) = NonEmptyText Text
-  deriving stock (Generic, Show, Read, Lift)
+  deriving stock (Data, Generic, Show, Read, Lift)
   deriving newtype (Eq, Ord, ToJSON, MonoFoldable)
 
 type instance Element (NonEmptyText _n) = Char

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           string-variants
-version:        0.3.0.1
+version:        0.3.1.0
 synopsis:       Constrained text newtypes
 description:    See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category:       Data


### PR DESCRIPTION
I want to use `NonEmptyText` in a type with a lot of constructors (specifically, an `optparse-generic` command type) which already uses the `Data` typeclass to so I can use [toConstr](https://hackage.haskell.org/package/base-4.19.1.0/docs/Data-Data.html#v:toConstr). `NonEmptyText` does not implement `Data` (it doesn't implement any of the `optparse` instances either, but I can work around those -- I can't work around `Data`). I think it should be safe to add `Data` to `NonEmptyText` because the magic all happens at compile time, but please let me know if I'm wrong.