### PR TITLE
Add more typeclass instances for NonEmptyText and NullableNonEmptyText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.1.1] - 2024-10-31
+
+- Add `Hashable` and `NFData` instances to `NonEmptyText`.
+- Add `Data`, `Ord`, `Hashable` and `NFData` instances to `NullableNonEmptyText`.
+- Add dependences on `deepseq` and `hashable`.
+
 ## [0.3.1.0] - 2024-02-29
 
 - Add `Data` instance to `NonEmptyText`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add `Hashable` and `NFData` instances to `NonEmptyText`.
 - Add `Data`, `Ord`, `Hashable` and `NFData` instances to `NullableNonEmptyText`.
-- Add dependences on `deepseq` and `hashable`.
+- Add dependencies on `deepseq` and `hashable`.
 
 ## [0.3.1.0] - 2024-02-29
 

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ library:
   dependencies:
     - QuickCheck
     - bytestring
+    - hashable
     - mono-traversable
     - refined
     - string-conversions

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ library:
   dependencies:
     - QuickCheck
     - bytestring
+    - deepseq
     - hashable
     - mono-traversable
     - refined

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: string-variants
-version: 0.3.0.1
+version: 0.3.1.1
 synopsis: Constrained text newtypes
 description: See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category: Data

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/3sr1dn11ma4q0fg4rzma9gd5jk1dr63b-string-variants-0.3.1.1

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/3sr1dn11ma4q0fg4rzma9gd5jk1dr63b-string-variants-0.3.1.1

--- a/src/Data/StringVariants/NonEmptyText/Internal.hs
+++ b/src/Data/StringVariants/NonEmptyText/Internal.hs
@@ -35,7 +35,7 @@ import Prelude
 -- | Non Empty Text, requires the input is between 1 and @n@ chars and not just whitespace.
 newtype NonEmptyText (n :: Nat) = NonEmptyText Text
   deriving stock (Data, Generic, Show, Read, Lift)
-  deriving newtype (Eq, Ord, ToJSON, MonoFoldable, Hashable, Semigroup, NFData)
+  deriving newtype (Eq, Ord, ToJSON, MonoFoldable, Hashable, NFData)
 
 type instance Element (NonEmptyText _n) = Char
 

--- a/src/Data/StringVariants/NonEmptyText/Internal.hs
+++ b/src/Data/StringVariants/NonEmptyText/Internal.hs
@@ -11,11 +11,13 @@
 
 module Data.StringVariants.NonEmptyText.Internal where
 
+import Control.DeepSeq (NFData)
 import Control.Monad (when)
 import Data.Aeson (FromJSON (..), ToJSON, withText)
 import Data.ByteString
 import Data.Coerce
 import Data.Data (Data)
+import Data.Hashable (Hashable)
 import Data.MonoTraversable
 import Data.Proxy
 import Data.Sequences
@@ -33,7 +35,7 @@ import Prelude
 -- | Non Empty Text, requires the input is between 1 and @n@ chars and not just whitespace.
 newtype NonEmptyText (n :: Nat) = NonEmptyText Text
   deriving stock (Data, Generic, Show, Read, Lift)
-  deriving newtype (Eq, Ord, ToJSON, MonoFoldable)
+  deriving newtype (Eq, Ord, ToJSON, MonoFoldable, Hashable, Semigroup, NFData)
 
 type instance Element (NonEmptyText _n) = Char
 

--- a/src/Data/StringVariants/NullableNonEmptyText.hs
+++ b/src/Data/StringVariants/NullableNonEmptyText.hs
@@ -80,8 +80,8 @@ import Prelude
 --
 --   Use 'nullableNonEmptyTextToMaybeNonEmptyText' to extract @Maybe (NonEmptyText n)@ from @NullableNonEmptyText n@.
 newtype NullableNonEmptyText n = NullableNonEmptyText (Maybe (NonEmptyText n))
-  deriving stock (Generic, Show, Read, Lift)
-  deriving newtype (Eq)
+  deriving stock (Data, Generic, Show, Read, Lift)
+  deriving newtype (Eq, Ord, MonoFoldable, Hashable)
 
 mkNullableNonEmptyText :: forall n. (KnownNat n, 1 <= n) => Text -> Maybe (NullableNonEmptyText n)
 mkNullableNonEmptyText t

--- a/src/Data/StringVariants/NullableNonEmptyText.hs
+++ b/src/Data/StringVariants/NullableNonEmptyText.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -30,14 +31,18 @@ module Data.StringVariants.NullableNonEmptyText
   )
 where
 
+import Control.DeepSeq (NFData)
 import Control.Monad
 import Data.Aeson
 import Data.Aeson qualified as J
 import Data.Aeson.Key qualified as J
 import Data.Aeson.Types qualified as J
-import Data.Data (Proxy (..))
+import Data.Data (Data, Proxy (..))
+import Data.Hashable (Hashable)
 import Data.Maybe (fromMaybe)
+import Data.MonoTraversable (MonoFoldable)
 import Data.StringVariants.NonEmptyText
+import Data.StringVariants.NonEmptyText.Internal (NonEmptyText (..))
 import Data.StringVariants.Util
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -81,7 +86,7 @@ import Prelude
 --   Use 'nullableNonEmptyTextToMaybeNonEmptyText' to extract @Maybe (NonEmptyText n)@ from @NullableNonEmptyText n@.
 newtype NullableNonEmptyText n = NullableNonEmptyText (Maybe (NonEmptyText n))
   deriving stock (Data, Generic, Show, Read, Lift)
-  deriving newtype (Eq, Ord, MonoFoldable, Hashable)
+  deriving newtype (Eq, Ord, Hashable, NFData)
 
 mkNullableNonEmptyText :: forall n. (KnownNat n, 1 <= n) => Text -> Maybe (NullableNonEmptyText n)
 mkNullableNonEmptyText t

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           string-variants
-version:        0.3.0.1
+version:        0.3.1.1
 synopsis:       Constrained text newtypes
 description:    See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category:       Data

--- a/string-variants.cabal
+++ b/string-variants.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           string-variants
-version:        0.3.1.0
+version:        0.3.0.1
 synopsis:       Constrained text newtypes
 description:    See README at <https://github.com/MercuryTechnologies/string-variants#readme>.
 category:       Data
@@ -79,6 +79,8 @@ library
     , aeson >=2.0.0.0
     , base >=4.16 && <5
     , bytestring
+    , deepseq
+    , hashable
     , mono-traversable
     , refined
     , string-conversions


### PR DESCRIPTION
In this PR, I added some typeclass instances for `NonEmptyText` and `NullableNonEmptyText`. These come from three sources.

1. I standardized the existing typeclass coverage between the two types.
2. I added some typeclasses instances that come from `Text`
3. I added a `Hashable` instance to both classes because that seems generally useful.

Adding `NFData` (category 2) required adding a dependency on `deepseq`.
Adding `Hashable` required adding a dependency on `hashable`.

If we prefer to keep this library low-dependency, I'm happy to remove those two instances. The instance I actually need for my work is `Ord (NullableNonEmptyText n)`.