### PR TITLE
Pin actions to hashes using pinact [workflow-enforcer]

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,15 +17,15 @@ jobs:
     env:
       CONFIG: "--enable-tests"
     steps:
-      - uses: actions/checkout@v3
-      - uses: haskell-actions/setup@v2
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: haskell-actions/setup@7909071ceec0344debcc968c6c7a96a52e8dd0d7 # v2.8.1
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
-      - uses: actions/cache@v3
+      - uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         with:
           path: |
             ${{ steps.setup-haskell-cabal.outputs.cabal-store }}


### PR DESCRIPTION
This PR pins action references to commit hashes to mitigate supply chain attacks where a bad actor will push a new tag or override an existing tag, leading to us running malicious code immediately without explicitly updating.

Documentation on how to use pinact can be found in the internal developers site.
